### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can find passb in the [Firefox addon repository](https://addons.mozilla.org/
 
 When you have installed the addon, you also have to install the host application and restart your browser.
 
-This is documented here: [host application](./host_application.html)
+This is documented here: [host application](./host_application.md)
 
 ### Customizing passb
 


### PR DESCRIPTION
The relative link to the html page works on the github pages html page but not in the README file.
To get consistent functionality the link should point to the md file.
This will be automatically translated to html by Jekyll as described [here](https://github.com/blog/2290-relative-links-for-github-pages).